### PR TITLE
fixing example webapp mobile view with html meta

### DIFF
--- a/WebApp/src/jsMain/resources/index.html
+++ b/WebApp/src/jsMain/resources/index.html
@@ -2,6 +2,11 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="format-detection" content="telephone=no"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <meta name="HandheldFriendly" content="True"/>
+        <meta name="robots" content="noindex,nofollow"/>
+        <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
         <title>Web App Example</title>
     </head>
     <body>


### PR DESCRIPTION
I think it's better to show the desired <<"meta">> in the example so that the application does not spread and there are no questions - wtf?